### PR TITLE
feat: Add freezing and unfreezing of sources

### DIFF
--- a/rust/lon/src/cli.rs
+++ b/rust/lon/src/cli.rs
@@ -52,7 +52,10 @@ enum Commands {
     /// When you change the revision,  the source is locked to this revision.
     Modify(ModifyArgs),
     /// Remove an existing source
-    Remove(RemoveArgs),
+    Remove(SourceArgs),
+    /// Freeze an existing source
+    Freeze(SourceArgs),
+    Unfreeze(SourceArgs),
 }
 
 #[derive(Subcommand)]
@@ -83,6 +86,9 @@ struct AddGitArgs {
     /// Fetch submodules
     #[arg(long)]
     submodules: bool,
+    /// Freeze the source
+    #[arg(long, default_value_t = false)]
+    frozen: bool,
 }
 
 #[derive(Args)]
@@ -99,6 +105,9 @@ struct AddGitHubArgs {
     /// Revision to lock
     #[arg(short, long)]
     revision: Option<String>,
+    /// Freeze the source
+    #[arg(long, default_value_t = false)]
+    frozen: bool,
 }
 
 #[derive(Args)]
@@ -125,7 +134,7 @@ struct ModifyArgs {
 }
 
 #[derive(Args)]
-struct RemoveArgs {
+struct SourceArgs {
     /// Name of the source
     name: String,
 }
@@ -172,6 +181,8 @@ impl Commands {
             Self::Update(args) => update(directory, &args),
             Self::Modify(args) => modify(directory, &args),
             Self::Remove(args) => remove(directory, &args),
+            Self::Freeze(args) => freeze(directory, &args),
+            Self::Unfreeze(args) => unfreeze(directory, &args),
         }
     }
 }
@@ -208,6 +219,7 @@ fn add_git(directory: impl AsRef<Path>, args: &AddGitArgs) -> Result<()> {
         &args.branch,
         args.revision.as_ref(),
         args.submodules,
+        args.frozen,
     )?;
 
     sources.add(&args.name, Source::Git(source));
@@ -232,7 +244,13 @@ fn add_github(directory: impl AsRef<Path>, args: &AddGitHubArgs) -> Result<()> {
 
     log::info!("Adding {name}...");
 
-    let source = GitHubSource::new(owner, repo, &args.branch, args.revision.as_ref())?;
+    let source = GitHubSource::new(
+        owner,
+        repo,
+        &args.branch,
+        args.revision.as_ref(),
+        args.frozen,
+    )?;
 
     sources.add(&name, Source::GitHub(source));
 
@@ -320,7 +338,7 @@ fn modify(directory: impl AsRef<Path>, args: &ModifyArgs) -> Result<()> {
     Ok(())
 }
 
-fn remove(directory: impl AsRef<Path>, args: &RemoveArgs) -> Result<()> {
+fn remove(directory: impl AsRef<Path>, args: &SourceArgs) -> Result<()> {
     let mut sources = Sources::read(&directory)?;
 
     if !sources.contains(&args.name) {
@@ -330,6 +348,40 @@ fn remove(directory: impl AsRef<Path>, args: &RemoveArgs) -> Result<()> {
     log::info!("Removing {}...", args.name);
 
     sources.remove(&args.name);
+
+    sources.write(&directory)?;
+    LonNix::update(&directory)?;
+
+    Ok(())
+}
+
+fn freeze(directory: impl AsRef<Path>, args: &SourceArgs) -> Result<()> {
+    let mut sources = Sources::read(&directory)?;
+
+    let Some(source) = sources.get_mut(&args.name) else {
+        bail!("Source {} doesn't exist", args.name)
+    };
+
+    log::info!("Freezing {}...", args.name);
+
+    source.freeze();
+
+    sources.write(&directory)?;
+    LonNix::update(&directory)?;
+
+    Ok(())
+}
+
+fn unfreeze(directory: impl AsRef<Path>, args: &SourceArgs) -> Result<()> {
+    let mut sources = Sources::read(&directory)?;
+
+    let Some(source) = sources.get_mut(&args.name) else {
+        bail!("Source {} doesn't exist", args.name)
+    };
+
+    log::info!("Unfreezing {}...", args.name);
+
+    source.unfreeze();
 
     sources.write(&directory)?;
     LonNix::update(&directory)?;

--- a/rust/lon/src/lock/v1.rs
+++ b/rust/lon/src/lock/v1.rs
@@ -28,6 +28,8 @@ pub enum FetchType {
 #[serde(rename_all = "camelCase")]
 pub struct GitSource {
     pub fetch_type: FetchType,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub frozen: bool,
 
     pub branch: String,
     pub revision: String,
@@ -42,6 +44,8 @@ pub struct GitSource {
 #[serde(rename_all = "camelCase")]
 pub struct GitHubSource {
     pub fetch_type: FetchType,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub frozen: bool,
 
     pub owner: String,
     pub repo: String,


### PR DESCRIPTION
This adds two subcommands: `freeze NAME` and `thaw NAME`. A frozen source is not updated when running `lon update`. When adding a source, it can be declared frozen from the start with the flag `--frozen`

Fixes #4