### PR TITLE
cli: allow to set directory via env

### DIFF
--- a/rust/lon/src/cli.rs
+++ b/rust/lon/src/cli.rs
@@ -154,7 +154,10 @@ impl Cli {
 
         let directory = match cli.directory {
             Some(directory) => directory,
-            None => std::env::current_dir().unwrap_or_default(),
+            None => match std::env::var("LON_DIRECTORY") {
+                Ok(dir) => PathBuf::from(dir),
+                Err(_) => std::env::current_dir().unwrap_or_default(),
+            },
         };
 
         match cli.commands.call(directory) {


### PR DESCRIPTION
This is just a convenience feature for multiple manual commands. One can now just set LON_DIRECTORY=XYZ in his e.g. nix-shell.