### PR TITLE
bot: Add detailed option

### DIFF
--- a/rust/lon/src/bot.rs
+++ b/rust/lon/src/bot.rs
@@ -12,5 +12,10 @@ pub trait Forge {
     /// Open a PR on the forge.
     ///
     /// Specify the source branch for the PR and the name of the dependency that is being updated.
-    fn open_pull_request(&self, source_branch: &str, name: &str) -> Result<String>;
+    fn open_pull_request(
+        &self,
+        source_branch: &str,
+        name: &str,
+        body: Option<String>,
+    ) -> Result<String>;
 }

--- a/rust/lon/src/bot/forgejo.rs
+++ b/rust/lon/src/bot/forgejo.rs
@@ -31,6 +31,8 @@ struct PullRequest {
     head: String,
     base: String,
     title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -122,13 +124,14 @@ impl Forgejo {
 }
 
 impl Forge for Forgejo {
-    fn open_pull_request(&self, branch: &str, name: &str) -> Result<String> {
+    fn open_pull_request(&self, branch: &str, name: &str, body: Option<String>) -> Result<String> {
         let repository = self.get_repository()?;
 
         let pull_request = PullRequest {
             head: branch.into(),
             base: repository.default_branch.clone(),
             title: format!("lon: update {name}"),
+            body,
         };
 
         let url = format!("{}/pulls", self.repo_api_url());

--- a/rust/lon/src/bot/github.rs
+++ b/rust/lon/src/bot/github.rs
@@ -31,6 +31,8 @@ struct PullRequest {
     head: String,
     base: String,
     title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
     maintainer_can_modify: bool,
 }
 
@@ -130,13 +132,14 @@ impl GitHub {
 }
 
 impl Forge for GitHub {
-    fn open_pull_request(&self, branch: &str, name: &str) -> Result<String> {
+    fn open_pull_request(&self, branch: &str, name: &str, body: Option<String>) -> Result<String> {
         let repository = self.get_repository()?;
 
         let pull_request = PullRequest {
             head: branch.into(),
             base: repository.default_branch.clone(),
             title: format!("lon: update {name}"),
+            body,
             maintainer_can_modify: true,
         };
 

--- a/rust/lon/src/bot/gitlab.rs
+++ b/rust/lon/src/bot/gitlab.rs
@@ -35,11 +35,12 @@ impl GitLab {
 }
 
 impl Forge for GitLab {
-    fn open_pull_request(&self, branch: &str, name: &str) -> Result<String> {
+    fn open_pull_request(&self, branch: &str, name: &str, body: Option<String>) -> Result<String> {
         let merge_request = MergeRequest {
             source_branch: branch.into(),
             target_branch: self.default_branch.clone(),
             title: format!("lon: update {name}"),
+            body,
             remove_source_branch: true,
             allow_collaboration: true,
             labels: self.labels.join(","),
@@ -71,6 +72,8 @@ struct MergeRequest {
     source_branch: String,
     target_branch: String,
     title: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
     remove_source_branch: bool,
     allow_collaboration: bool,
     labels: String,

--- a/rust/lon/src/git.rs
+++ b/rust/lon/src/git.rs
@@ -191,6 +191,114 @@ pub fn get_last_modified(url: &str, rev: &str) -> Result<u64> {
         .context("Failed to parse last modified timestamp.")
 }
 
+/// List the commits between two revisions
+pub fn rev_list(
+    url: &str,
+    old_revision: &str,
+    new_revision: &str,
+    num_commits: usize,
+) -> Result<String> {
+    let tmp_dir = TempDir::new()?;
+    let mut output: Output;
+
+    // Init a new git directory
+    output = Command::new("git")
+        .arg("--git-dir")
+        .arg(tmp_dir.path())
+        .arg("init")
+        .output()
+        .context("Failed to execute git init. Most likely it's not on PATH")?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to initialize a fresh git repository\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    // Add the repository as a remote
+    output = Command::new("git")
+        .arg("--git-dir")
+        .arg(tmp_dir.path())
+        .args(["remote", "add", "origin", url])
+        .output()
+        .context("Failed to execute git remote add.")?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to add the remote {}\n{}",
+            url,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    // Fetch the old revision
+    output = Command::new("git")
+        .arg("--git-dir")
+        .arg(tmp_dir.path())
+        .args([
+            "fetch",
+            "--depth=1",
+            "--no-show-forced-updates",
+            "origin",
+            old_revision,
+        ])
+        .output()
+        .context("Failed to execute git fetch.")?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to fetch the revision {}\n{}",
+            old_revision,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    // Fetch the new revision, up to the old one
+    output = Command::new("git")
+        .arg("--git-dir")
+        .arg(tmp_dir.path())
+        .args([
+            "fetch",
+            "--no-show-forced-updates",
+            "--negotiation-tip",
+            old_revision,
+            "origin",
+            new_revision,
+        ])
+        .arg(format!("--depth={num_commits}"))
+        .output()
+        .context("Failed to execute git fetch.")?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to fetch the revision {}\n{}",
+            new_revision,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    // Get the history
+    output = Command::new("git")
+        .arg("--git-dir")
+        .arg(tmp_dir.path())
+        .args(["rev-list", "--oneline"])
+        .arg(format!("{old_revision}..{new_revision}"))
+        .output()
+        .context("Failed to execute git rev-list.")?;
+
+    if !output.status.success() {
+        bail!(
+            "Failed to list the history for {}..{}\n{}",
+            old_revision,
+            new_revision,
+            String::from_utf8_lossy(&output.stderr)
+        )
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim_end().into())
+}
+
 pub fn add(directory: impl AsRef<Path>, args: &[&Path]) -> Result<()> {
     let output = Command::new("git")
         .arg("-C")

--- a/rust/lon/src/sources.rs
+++ b/rust/lon/src/sources.rs
@@ -1,6 +1,11 @@
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, fmt, path::Path};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
+use reqwest::{
+    blocking::{Client, Response},
+    header::{self, HeaderName, HeaderValue},
+};
+use serde::Deserialize;
 
 use crate::{
     git::{self, Revision},
@@ -13,9 +18,11 @@ const GITHUB_URL: &str = "https://github.com";
 /// Informaton summarizing an update.
 ///
 /// Represents an update of a single source.
+#[derive(Clone)]
 pub struct UpdateSummary {
     pub old_revision: Revision,
     pub new_revision: Revision,
+    pub rev_list: Vec<String>,
 }
 
 impl UpdateSummary {
@@ -26,6 +33,22 @@ impl UpdateSummary {
         Self {
             old_revision,
             new_revision,
+            rev_list: vec![],
+        }
+    }
+
+    pub fn message(&self, indent: usize) -> Option<String> {
+        if self.rev_list.is_empty() {
+            None
+        } else {
+            let prefix = " ".repeat(indent);
+
+            Some(
+                std::iter::once(format!("{prefix}Last {} commits:\n", self.rev_list.len()))
+                    .chain(self.rev_list.iter().map(|rev| format!("{prefix}  {rev}\n")))
+                    .collect::<Vec<String>>()
+                    .concat(),
+            )
         }
     }
 }
@@ -86,6 +109,63 @@ pub enum Source {
     GitHub(GitHubSource),
 }
 
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct GitHubDiff {
+    pub commits: Vec<GitHubDiffCommitInfo>,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct GitHubDiffCommitInfo {
+    pub sha: String,
+    pub commit: GitHubDiffCommit,
+}
+
+#[allow(unused)]
+#[derive(Debug, Deserialize)]
+struct GitHubDiffCommit {
+    pub message: String,
+}
+
+impl fmt::Display for GitHubDiffCommitInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{} {}",
+            &self.sha[..7],
+            self.commit
+                .message
+                .lines()
+                .next()
+                .expect("Failed to get commit message")
+        )
+    }
+}
+
+fn fetch_github_api(path: &str) -> Result<Response> {
+    let url = &format!("https://api.github.com/{path}");
+
+    let mut headers = header::HeaderMap::new();
+    headers.insert(
+        header::ACCEPT,
+        HeaderValue::from_static("application/vnd.github+json"),
+    );
+    headers.insert(
+        HeaderName::from_static("x-github-api-version"),
+        HeaderValue::from_static("2022-11-28"),
+    );
+
+    Client::builder()
+        .user_agent("LonBot")
+        .default_headers(headers)
+        .build()
+        .context("Failed to build the HTTP client")?
+        .get(url)
+        .send()
+        .with_context(|| format!("Failed to send POST request to {url}"))
+}
+
 impl Source {
     pub fn update(&mut self) -> Result<Option<UpdateSummary>> {
         match self {
@@ -120,6 +200,46 @@ impl Source {
         match self {
             Self::Git(s) => s.frozen,
             Self::GitHub(s) => s.frozen,
+        }
+    }
+
+    pub fn rev_list(&self, summary: &mut UpdateSummary, num_commits: usize) -> Result<()> {
+        match self {
+            Self::Git(s) => {
+                git::rev_list(
+                    &s.url,
+                    summary.old_revision.as_str(),
+                    summary.new_revision.as_str(),
+                    num_commits,
+                )?
+                .lines()
+                .for_each(|rev| summary.rev_list.push(rev.into()));
+
+                Ok(())
+            }
+            Self::GitHub(s) => {
+                let path = format!(
+                    "repos/{}/{}/compare/{}...{}",
+                    s.owner, s.repo, summary.old_revision, summary.new_revision
+                );
+
+                let res = fetch_github_api(&path)?;
+
+                let status = res.status();
+                if !status.is_success() {
+                    bail!("Failed to fetch {path}: {status}:\n{}", res.text()?)
+                }
+
+                let diff: GitHubDiff = serde_json::from_str(&res.text()?)?;
+
+                diff.commits
+                    .iter()
+                    .rev()
+                    .take(num_commits)
+                    .for_each(|info| summary.rev_list.push(info.to_string()));
+
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
This will list the intermediate commits between the old and the new revision. It makes it easier to see if anything of note hapenned.

![image](https://github.com/user-attachments/assets/b72741de-8b12-4c0e-a736-f26191f04153)

Follows all previous PRs