### PR TITLE
cli: init from npins

### DIFF
--- a/rust/lon/src/cli.rs
+++ b/rust/lon/src/cli.rs
@@ -11,7 +11,7 @@ use crate::{
     bot::{Forge, Forgejo, GitHub, GitLab},
     commit_message::CommitMessage,
     git,
-    init::{Convertible, niv},
+    init::{Convertible, niv, npins},
     lock::Lock,
     lon_nix::LonNix,
     sources::{GitHubSource, GitSource, Source, Sources},
@@ -82,6 +82,7 @@ struct InitArgs {
 #[derive(Clone, ValueEnum)]
 enum LockFileType {
     Niv,
+    Npins,
 }
 
 #[derive(Subcommand)]
@@ -261,13 +262,13 @@ fn init(directory: impl AsRef<Path>, args: &InitArgs) -> Result<()> {
         bail!("No lock file type is provided");
     };
 
-    let lock_file = match lock_file_type {
-        LockFileType::Niv => niv::LockFile::from_file(path)?,
-    };
-
     log::info!("Initializing lon.lock from {path:?}");
 
-    let sources = lock_file.convert()?;
+    let sources = match lock_file_type {
+        LockFileType::Niv => niv::LockFile::from_file(path)?.convert()?,
+        LockFileType::Npins => npins::LockFile::from_file(path)?.convert()?,
+    };
+
     sources.write(&directory)?;
 
     Ok(())

--- a/rust/lon/src/init.rs
+++ b/rust/lon/src/init.rs
@@ -1,4 +1,5 @@
 pub mod niv;
+pub mod npins;
 
 use anyhow::Result;
 

--- a/rust/lon/src/init/npins.rs
+++ b/rust/lon/src/init/npins.rs
@@ -1,0 +1,215 @@
+use std::{collections::BTreeMap, path::Path};
+
+use anyhow::{Context, Result, bail};
+use regex::Regex;
+use serde::Deserialize;
+
+use crate::{
+    init::Convertible,
+    sources::{GitHubSource, GitSource, Source, Sources},
+};
+
+#[derive(Debug, Deserialize)]
+pub struct LockFile {
+    pins: BTreeMap<String, Pin>,
+    version: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum Repository {
+    Git {
+        /// URL to the Git repository
+        url: String,
+    },
+    Forgejo {
+        server: String,
+        owner: String,
+        repo: String,
+    },
+    GitHub {
+        /// "owner/repo"
+        owner: String,
+        repo: String,
+    },
+    GitLab {
+        /// usually "owner/repo" or "group/owner/repo" (without leading or trailing slashes)
+        repo_path: String,
+        /// Of the kind <https://gitlab.example.org/>
+        ///
+        /// It must fit into the schema `<server>/<owner>/<repo>` to get a repository's URL.
+        server: String,
+        /// access token for private repositories
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        private_token: Option<String>,
+    },
+}
+
+// HACK: We know that a Git pin has a branch associated to it and GitRelease has none,
+//       but to unify the behaviour, we set them bot to `Option`s
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum Pin {
+    Git {
+        repository: Repository,
+        branch: Option<String>,
+        revision: String,
+        submodules: bool,
+        #[serde(default)]
+        frozen: bool,
+    },
+    GitRelease {
+        repository: Repository,
+        branch: Option<String>,
+        revision: String,
+        submodules: bool,
+        #[serde(default)]
+        frozen: bool,
+    },
+    Channel {
+        #[serde(rename = "name")]
+        channel: String,
+        url: String,
+        #[serde(default)]
+        frozen: bool,
+    },
+}
+
+impl LockFile {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
+        let lock_json = std::fs::read_to_string(path.as_ref())
+            .with_context(|| format!("Failed to read {:?}", path.as_ref()))?;
+
+        serde_json::from_str(&lock_json).context("Failed to deserialize Npins lock file")
+    }
+}
+
+impl Convertible for LockFile {
+    fn convert(&self) -> Result<Sources> {
+        let mut sources = Sources::default();
+
+        if self.version == 1 {
+            bail!("Unsupported npins lockfile version: {}", &self.version)
+        }
+
+        let re = Regex::new(
+            r"https://releases\.nixos\.org/.*\.(?<shortrev>[a-f0-9]+)/nixexprs\.tar\.xz",
+        )?;
+
+        for (name, pin) in &self.pins {
+            log::info!("Converting {name}...");
+
+            let source = match pin {
+                Pin::Channel {
+                    channel,
+                    url,
+                    frozen,
+                } => {
+                    let Some(matched) = re.captures(url) else {
+                        bail!("Cannot extract revision from the channel url: {url}")
+                    };
+
+                    Source::GitHub(GitHubSource::new(
+                        "NixOS",
+                        "nixpkgs",
+                        Some(channel),
+                        Some(&matched["shortrev"].into()),
+                        *frozen,
+                    )?)
+                }
+                Pin::Git {
+                    repository,
+                    branch,
+                    revision,
+                    submodules,
+                    frozen,
+                }
+                | Pin::GitRelease {
+                    repository,
+                    branch,
+                    revision,
+                    submodules,
+                    frozen,
+                } => match repository {
+                    Repository::Git { url } => Source::Git(GitSource::new(
+                        url,
+                        branch.as_ref(),
+                        Some(revision),
+                        *submodules,
+                        *frozen,
+                    )?),
+                    Repository::GitHub { owner, repo } => {
+                        if *submodules {
+                            Source::Git(GitSource::new(
+                                &format!("https://github.com/{owner}/{repo}"),
+                                branch.as_ref(),
+                                Some(revision),
+                                *submodules,
+                                *frozen,
+                            )?)
+                        } else {
+                            Source::GitHub(GitHubSource::new(
+                                owner,
+                                repo,
+                                branch.as_ref(),
+                                Some(revision),
+                                *frozen,
+                            )?)
+                        }
+                    }
+                    Repository::Forgejo {
+                        server,
+                        owner,
+                        repo,
+                    } => Source::Git(GitSource::new(
+                        &format!("{server}/{owner}/{repo}"),
+                        branch.as_ref(),
+                        Some(revision),
+                        *submodules,
+                        *frozen,
+                    )?),
+                    Repository::GitLab {
+                        repo_path,
+                        server,
+                        private_token,
+                    } => {
+                        if private_token.is_some() {
+                            log::warn!(
+                                "GitLab source {name} is configured with a PAT, which unsupported in lon"
+                            );
+                        }
+                        Source::Git(GitSource::new(
+                            &format!("{server}/{repo_path}"),
+                            branch.as_ref(),
+                            Some(revision),
+                            *submodules,
+                            *frozen,
+                        )?)
+                    }
+                },
+            };
+
+            sources.add(name, source);
+        }
+
+        Ok(sources)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl LockFile {
+        fn from_str(s: &str) -> Result<Self> {
+            serde_json::from_str(s).context("Failed to deserialize npins lock file")
+        }
+    }
+
+    #[test]
+    fn parse_npins_lock_file() -> Result<()> {
+        LockFile::from_str(include_str!("../../tests/npins.json"))?;
+        Ok(())
+    }
+}

--- a/rust/lon/tests/npins.json
+++ b/rust/lon/tests/npins.json
@@ -1,0 +1,86 @@
+{
+  "pins": {
+    "agenix": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "ryantm",
+        "repo": "agenix"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "0.15.0",
+      "revision": "564595d0ad4be7277e07fa63b5a991b3c645655d",
+      "url": "https://api.github.com/repos/ryantm/agenix/tarball/refs/tags/0.15.0",
+      "hash": "sha256-ipqShkBmHKC9ft1ZAsA6aeKps32k7+XZSPwfxeHLsAU="
+    },
+    "arkheon": {
+      "type": "Git",
+      "repository": {
+        "type": "GitHub",
+        "owner": "RaitoBezarius",
+        "repo": "arkheon"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "3eea876b29217d01cf2ef03ea9fdd8779d28ad04",
+      "url": "https://github.com/RaitoBezarius/arkheon/archive/3eea876b29217d01cf2ef03ea9fdd8779d28ad04.tar.gz",
+      "hash": "sha256-+R6MhTXuSzNeGQiL4DQwlP5yNhmnhbf7pQWPUWgcZSM="
+    },
+    "colmena": {
+      "type": "Git",
+      "repository": {
+        "type": "Git",
+        "url": "https://git.dgnum.eu/DGNum/colmena"
+      },
+      "branch": "main",
+      "submodules": false,
+      "revision": "b5135dc8af1d7637b337cc2632990400221da577",
+      "url": null,
+      "hash": "sha256-7gg+K3PEYlN0sGPgDlmnM8zgDDIV505gNcwjFN61Qvk="
+    },
+    "nix-actions": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "Git",
+        "url": "https://git.dgnum.eu/DGNum/nix-actions.git"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "v0.5.1",
+      "revision": "06847b3256df402da0475dccb290832ec92a9f8c",
+      "url": null,
+      "hash": "sha256-2xOZdKiUfcriQFKG37vY96dgCJLndhLa7cGacq8+SA8="
+    },
+    "nixos-25.05": {
+      "type": "Channel",
+      "name": "nixos-25.05",
+      "url": "https://releases.nixos.org/nixos/25.05/nixos-25.05.803579.70c74b02eac4/nixexprs.tar.xz",
+      "hash": "sha256-0RxtgAd4gHYPFFwICal8k8hvJBOkCeTjFkh4HsqYDbE="
+    },
+    "nixos-unstable": {
+      "type": "Channel",
+      "name": "nixos-unstable",
+      "url": "https://releases.nixos.org/nixos/unstable/nixos-25.05pre797896.d89fc19e405c/nixexprs.tar.xz",
+      "hash": "sha256-bFJJ/qwB3VJ0nFuVYYHJXinT4tNJ2jhXTVT6SpYiFOM="
+    },
+    "wp4nix": {
+      "type": "Git",
+      "repository": {
+        "type": "GitLab",
+        "repo_path": "helsinki-systems/wp4nix",
+        "server": "https://git.helsinki.tools/"
+      },
+      "branch": "master",
+      "submodules": false,
+      "revision": "2fc9a0734168cab536e3129efa6397d6cd3ac89f",
+      "url": "https://git.helsinki.tools/api/v4/projects/helsinki-systems%2Fwp4nix/repository/archive.tar.gz?sha=2fc9a0734168cab536e3129efa6397d6cd3ac89f",
+      "hash": "sha256-abwqAZGsWuWqfxou8XlqedBvXsUw1/xanSgljLCJxdM="
+    }
+  },
+  "version": 6
+}


### PR DESCRIPTION
Follows #36 

This adds the conversion from npins to lon, with some caveats:
- Only `Git`, `GitRelease` and `Channel` pins are supported
- npins lockfile `v1` is unsupported as its structure is quite different