### PR TITLE
lon: don't abort on update fail

### DIFF
--- a/rust/lon/src/cli.rs
+++ b/rust/lon/src/cli.rs
@@ -4,7 +4,7 @@ use std::{
     process::ExitCode,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use crate::{
@@ -392,12 +392,15 @@ fn update(directory: impl AsRef<Path>, args: &UpdateArgs) -> Result<()> {
 
         log::info!("Updating {name}...");
 
-        let summary = source
-            .update()
-            .with_context(|| format!("Failed to update {name}"))?;
-
-        if let Some(summary) = summary {
-            commit_message.add_summary(name, summary);
+        match source.update() {
+            Ok(summary) => {
+                if let Some(summary) = summary {
+                    commit_message.add_summary(name, summary);
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to update {name}: {e}");
+            }
         }
     }
 
@@ -556,9 +559,13 @@ fn bot_fallible(directory: impl AsRef<Path>, forge: &impl Forge, base_ref: &str)
 
         log::info!("Updating {name}...");
 
-        let summary = source
-            .update()
-            .with_context(|| format!("Failed to update {name}"))?;
+        let summary = match source.update() {
+            Ok(summary) => summary,
+            Err(e) => {
+                log::warn!("Failed to update {name}: {e}");
+                continue;
+            }
+        };
 
         let Some(mut summary) = summary else {
             log::info!("No updates available");


### PR DESCRIPTION
Should close #62.

I tested this on my end.

Even though the diff is fairly small, I'm still very much a newbie when it comes to Rust, so please review it carefully.

I tried writing an integration test for this, but I quickly found out why there aren't any for the `update` subcommand already. I'm not sure whether this actually needs a test and, if so, how it should be implemented.