### PR TITLE
cli: always print full error

### DIFF
--- a/rust/lon/src/cli.rs
+++ b/rust/lon/src/cli.rs
@@ -223,12 +223,7 @@ impl Cli {
         match cli.commands.call(directory) {
             Ok(()) => ExitCode::SUCCESS,
             Err(err) => {
-                // When at least one -v is added, the source of the error is also printed.
-                if DEFAULT_LOG_LEVEL + usize::from(cli.verbose) >= 3 {
-                    log::error!("{err:#}");
-                } else {
-                    log::error!("{err}");
-                }
+                log::error!("{err:#}");
                 ExitCode::FAILURE
             }
         }


### PR DESCRIPTION
Without this change you'll get the following message if e.g. fetching a git-repo on `lon update` fails:

    $ cargo run -- update
    Updating foo...
    Failed to update foo

I'd argue that this is not good UX since the error is in no way actionable and even on the default verbosity setting I believe this should always be the case.

I know I proposed this in #60, but after having to remind more people to use `-v` after learning of it myself I'm proposing a patch now to do this.

An example-error message would be

    Failed to update foo: Failed to find newest revision for ssh://git@git.example.com/foo/bar (master).
    Are you sure the repo exists and contains the branch master?: Failed to reach ssh://git@git.example.com/foo/bar: git ls-remote failed with exit code 128:
    git@git.example.com: Permission denied (publickey). fatal: Could not read from remote repository. Please make sure you have the correct access rights and the repository exists.